### PR TITLE
Switch to psycopg v3 driver

### DIFF
--- a/app/core.py
+++ b/app/core.py
@@ -73,10 +73,10 @@ def _build_customers_url_from_env():
         return inst
 
     if user and pwd and name and host:
-        return f"postgresql+psycopg2://{user}:{quote_plus(pwd)}@{host}:5432/{name}"
+        return f"postgresql+psycopg://{user}:{quote_plus(pwd)}@{host}:5432/{name}"
     if user and pwd and name and inst:
         # App Engine Unix socket
-        return f"postgresql+psycopg2://{user}:{quote_plus(pwd)}@/{name}?host=/cloudsql/{inst}"
+        return f"postgresql+psycopg://{user}:{quote_plus(pwd)}@/{name}?host=/cloudsql/{inst}"
 
     # 3) Fall back to the primary DATABASE_URL when nothing else is configured
     primary_url = os.environ.get("DATABASE_URL")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ Werkzeug==2.3.7
 SQLAlchemy==2.0.36
 python-dotenv==1.0.1
 python-dateutil==2.9.0.post0
-psycopg2-binary==2.9.9
+psycopg[binary]==3.2.1
 stripe==9.4.0
 gunicorn==22.0.0


### PR DESCRIPTION
## Summary
- switch the PostgreSQL dependency to psycopg v3 binary wheels that support Python 3.13
- update customer database DSN builders to point SQLAlchemy at the psycopg v3 dialect

## Testing
- python -m pip install -r requirements.txt *(fails: proxy blocked access to package index)*

------
https://chatgpt.com/codex/tasks/task_e_68dff14f0ca08331a50e25f90a20cd1d