### PR TITLE
Fix dashboard date filtering and expense amount types

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -240,9 +240,9 @@ class Expense(Base):
     description = Column(Text, default="")
     currency = Column(String(8), nullable=False, default="EUR")
     vat_rate = Column(Numeric(5, 2), nullable=False, default=21.00)
-    amount_net = Column(Numeric(12, 2), nullable=False, default=0)
-    vat_amount = Column(Numeric(12, 2), nullable=False, default=0)
-    amount_gross = Column(Numeric(12, 2), nullable=False, default=0)
+    amount_net = Column(TextDecimal(12, 2), nullable=False, default=0)
+    vat_amount = Column(TextDecimal(12, 2), nullable=False, default=0)
+    amount_gross = Column(TextDecimal(12, 2), nullable=False, default=0)
     receipt_path = Column(String(256))
 
     invoice_id = Column(BigInteger, ForeignKey("invoices.id"), nullable=True)

--- a/app/pages/dashboard.py
+++ b/app/pages/dashboard.py
@@ -1,6 +1,6 @@
 # app/pages/dashboard.py
 from datetime import date
-from sqlalchemy import select, func, cast, Numeric
+from sqlalchemy import Date, Numeric, cast, func, select
 
 from ..core import get_db, csrf_token, render
 from ..models import Payment, Expense, Invoice
@@ -11,13 +11,14 @@ def register(app):
     def dashboard():
         db = get_db(); company = ensure_company(db)
         today = date.today()
+        start_of_year = date(today.year, 1, 1)
         ytd_income = db.execute(
             select(
                 func.coalesce(
                     func.sum(cast(Payment.amount, Numeric(12, 2))),
                     0,
                 )
-            ).where(Payment.date >= date(today.year, 1, 1))
+            ).where(cast(Payment.date, Date) >= start_of_year)
         ).scalar_one()
         ytd_expenses = db.execute(
             select(
@@ -31,7 +32,13 @@ def register(app):
         vat = vat_summary(db, today.year, ((today.month - 1)//3)+1)
         recent_invoices = db.execute(select(Invoice).order_by(Invoice.issue_date.desc()).limit(6)).scalars().all()
         recent_expenses = db.execute(select(Expense).order_by(Expense.date.desc()).limit(6)).scalars().all()
-        recent_payments = db.execute(select(Payment).order_by(Payment.date.desc()).limit(6)).scalars().all()
+        recent_payments = (
+            db.execute(
+                select(Payment).order_by(cast(Payment.date, Date).desc()).limit(6)
+            )
+            .scalars()
+            .all()
+        )
 
         return render("dashboard.html",
             csrf_token=csrf_token(), company=company,


### PR DESCRIPTION
## Summary
- cast payment dates to real SQL dates when aggregating and ordering dashboard data
- map expense monetary columns through the TextDecimal adapter so legacy text data loads correctly

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e017afff1483319868d2a52514aa7d