### PR TITLE
Fix expense page crashes with legacy text data

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -234,12 +234,14 @@ class Payment(Base):
 class Expense(Base):
     __tablename__ = "expenses"
     id = Column(BigInteger, primary_key=True, autoincrement=True)
-    date = Column(Date, nullable=False, default=date.today)
+    # Legacy Render DB stores ISO strings; use TextDate wrapper for compatibility
+    date = Column(TextDate(), nullable=False, default=date.today)
     vendor = Column(String(160), nullable=False)
     category = Column(String(64), nullable=False)  # Freelancer, Subcontractor, Software, Travel...
     description = Column(Text, default="")
     currency = Column(String(8), nullable=False, default="EUR")
-    vat_rate = Column(Numeric(5, 2), nullable=False, default=21.00)
+    # Persisted as TEXT historically; wrap with TextDecimal to coerce safely
+    vat_rate = Column(TextDecimal(5, 2), nullable=False, default=21.00)
     amount_net = Column(TextDecimal(12, 2), nullable=False, default=0)
     vat_amount = Column(TextDecimal(12, 2), nullable=False, default=0)
     amount_gross = Column(TextDecimal(12, 2), nullable=False, default=0)


### PR DESCRIPTION
## Summary
- map the Expense.date column through the existing TextDate adapter to support ISO string values in production
- wrap the Expense.vat_rate column in TextDecimal so numeric calculations work with legacy text storage

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e01a57592483318a05e8cb3c9455c4