### PR TITLE
Fix dashboard date casting and centralize metrics service

### DIFF
--- a/app/accounting.py
+++ b/app/accounting.py
@@ -2,7 +2,7 @@ from datetime import date
 from decimal import Decimal, ROUND_HALF_UP, InvalidOperation
 import os
 
-from sqlalchemy import select
+from sqlalchemy import Date, cast, select
 from dateutil.relativedelta import relativedelta
 
 from .models import CompanySettings, InvoiceSequence, Invoice, InvoiceLine, Payment, Expense
@@ -112,7 +112,12 @@ def vat_summary(db, year: int, quarter: int):
             vat_out += dec(line.line_vat)
 
     vat_in = Decimal("0.00")
-    exps = db.execute(select(Expense).where(Expense.date >= q_start, Expense.date <= q_end)).scalars().all()
+    exps = db.execute(
+        select(Expense).where(
+            cast(Expense.date, Date) >= q_start,
+            cast(Expense.date, Date) <= q_end,
+        )
+    ).scalars().all()
     for e in exps:
         vat_in += dec(e.vat_amount)
 

--- a/app/pages/dashboard.py
+++ b/app/pages/dashboard.py
@@ -1,55 +1,19 @@
 # app/pages/dashboard.py
 from datetime import date
-from sqlalchemy import Date, Numeric, cast, func, select
 
 from ..core import get_db, csrf_token, render
-from ..models import Payment, Expense, Invoice
-from ..accounting import ensure_company, dec, vat_summary
+from ..accounting import ensure_company
+from ..services.dashboard import load_dashboard_context
 
 def register(app):
     @app.route("/", endpoint="dashboard")
     def dashboard():
         db = get_db(); company = ensure_company(db)
-        today = date.today()
-        start_of_year = date(today.year, 1, 1)
-        ytd_income = db.execute(
-            select(
-                func.coalesce(
-                    func.sum(cast(Payment.amount, Numeric(12, 2))),
-                    0,
-                )
-            ).where(cast(Payment.date, Date) >= start_of_year)
-        ).scalar_one()
-        ytd_expenses = db.execute(
-            select(
-                func.coalesce(
-                    func.sum(cast(Expense.amount_gross, Numeric(12, 2))),
-                    0,
-                )
-            ).where(Expense.date >= date(today.year, 1, 1))
-        ).scalar_one()
+        context = load_dashboard_context(db, today=date.today())
 
-        vat = vat_summary(db, today.year, ((today.month - 1)//3)+1)
-        recent_invoices = db.execute(select(Invoice).order_by(Invoice.issue_date.desc()).limit(6)).scalars().all()
-        raw_expenses = db.execute(select(Expense).order_by(Expense.date.desc()).limit(6)).scalars().all()
-        recent_expenses = [
-            (expense, dec(expense.amount_gross))
-            for expense in raw_expenses
-        ]
-        raw_payments = (
-            db.execute(
-                select(Payment).order_by(cast(Payment.date, Date).desc()).limit(6)
-            )
-            .scalars()
-            .all()
-        )
-        recent_payments = [
-            (payment, dec(payment.amount))
-            for payment in raw_payments
-        ]
-
-        return render("dashboard.html",
-            csrf_token=csrf_token(), company=company,
-            ytd_income=dec(ytd_income), ytd_expenses=dec(ytd_expenses),
-            **vat, recent_invoices=recent_invoices, recent_expenses=recent_expenses, recent_payments=recent_payments
+        return render(
+            "dashboard.html",
+            csrf_token=csrf_token(),
+            company=company,
+            **context,
         )

--- a/app/services/dashboard.py
+++ b/app/services/dashboard.py
@@ -1,0 +1,108 @@
+"""Utilities for assembling dashboard metrics in a DB-friendly way."""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict
+
+from sqlalchemy import Date, Numeric, cast, func, literal, select, case
+from sqlalchemy.orm import Session
+
+from ..accounting import dec, vat_summary
+from ..models import Expense, Invoice, Payment
+
+
+def _normalize_financial_entries() -> Any:
+    """Return a selectable that exposes payments/expenses with consistent types."""
+    payments = (
+        select(
+            cast(Payment.date, Date).label("entry_date"),
+            cast(Payment.amount, Numeric(12, 2)).label("amount"),
+            literal("income").label("kind"),
+        )
+    )
+
+    expenses = (
+        select(
+            cast(Expense.date, Date).label("entry_date"),
+            cast(Expense.amount_gross, Numeric(12, 2)).label("amount"),
+            literal("expense").label("kind"),
+        )
+    )
+
+    return payments.union_all(expenses).cte("financial_entries")
+
+
+def load_dashboard_context(db: Session, *, today: date | None = None) -> Dict[str, Any]:
+    """Collect all data required by the dashboard template.
+
+    The production database stores monetary values and dates as legacy TEXT columns.
+    To avoid `text >= date` errors (as seen on Render) we explicitly cast to
+    `DATE`/`NUMERIC` for every aggregate/order-by. The combined CTE also lets us
+    compute income and expense totals in a single round-trip.
+    """
+
+    today = today or date.today()
+    start_of_year = date(today.year, 1, 1)
+
+    entries = _normalize_financial_entries()
+
+    aggregates = db.execute(
+        select(
+            func.coalesce(
+                func.sum(
+                    case((entries.c.kind == "income", entries.c.amount), else_=0)
+                ),
+                0,
+            ).label("income"),
+            func.coalesce(
+                func.sum(
+                    case((entries.c.kind == "expense", entries.c.amount), else_=0)
+                ),
+                0,
+            ).label("expenses"),
+        ).where(entries.c.entry_date >= start_of_year)
+    ).one()
+
+    ytd_income = dec(aggregates.income)
+    ytd_expenses = dec(aggregates.expenses)
+
+    vat = vat_summary(db, today.year, ((today.month - 1) // 3) + 1)
+
+    recent_invoices = (
+        db.execute(
+            select(Invoice).order_by(Invoice.issue_date.desc(), Invoice.id.desc()).limit(6)
+        )
+        .scalars()
+        .all()
+    )
+
+    recent_expenses = (
+        db.execute(
+            select(Expense)
+            .order_by(cast(Expense.date, Date).desc(), Expense.id.desc())
+            .limit(6)
+        )
+        .scalars()
+        .all()
+    )
+    expenses_with_amounts = [(expense, dec(expense.amount_gross)) for expense in recent_expenses]
+
+    recent_payments = (
+        db.execute(
+            select(Payment)
+            .order_by(cast(Payment.date, Date).desc(), Payment.id.desc())
+            .limit(6)
+        )
+        .scalars()
+        .all()
+    )
+    payments_with_amounts = [(payment, dec(payment.amount)) for payment in recent_payments]
+
+    return {
+        "ytd_income": ytd_income,
+        "ytd_expenses": ytd_expenses,
+        **vat,
+        "recent_invoices": recent_invoices,
+        "recent_expenses": expenses_with_amounts,
+        "recent_payments": payments_with_amounts,
+    }


### PR DESCRIPTION
## Summary
- extract dashboard metrics gathering into a dedicated service that casts legacy text columns to proper SQL types
- update the dashboard view to rely on the service and flatten the render context
- cast expense dates in the VAT summary query to prevent text/date comparison errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0245c24dc833190d537e26e185163